### PR TITLE
feature/remove_abc

### DIFF
--- a/filterbyfilter/BaseScraper.py
+++ b/filterbyfilter/BaseScraper.py
@@ -1,12 +1,10 @@
-import abc
+from typing import NoReturn
 
 
-class BaseScraper(abc.ABC):
+class BaseScraper:
 
-    @abc.abstractmethod
-    def pull(self):
+    def pull(self) -> NoReturn:
         raise NotImplementedError('BaseScraper::pull()')
 
-    @abc.abstractmethod
-    def scrape(self):
+    def scrape(self) -> NoReturn:
         raise NotImplementedError('BaseScraper::scrape()')


### PR DESCRIPTION
Removes inheritance from abc in BaseScraper. Imports typing to specify NoReturn for functions which only raise.

Resolves: #5 